### PR TITLE
Add a Placeholder messages.json for the .github folder. 

### DIFF
--- a/.github/messages.json
+++ b/.github/messages.json
@@ -1,0 +1,6 @@
+{
+  "Please Ignore this file": {
+    "message": "This is just so that Web-EXT is happy",
+    "description": "It tries to map .github as a langauge :/ "
+  }
+}

--- a/.github/messages.json
+++ b/.github/messages.json
@@ -1,6 +1,6 @@
 {
   "Please Ignore this file": {
-    "message": "This is just so that Web-EXT is happy",
-    "description": "It tries to map .github as a langauge :/ "
+    "message": "This is just so that web-ext is happy",
+    "description": "Otherwise web-ext tries to map .github as a language."
   }
 }


### PR DESCRIPTION
Web-Ext is trying to see if the `.github` folder is a valid language. 
For that it needs to contain a messages.json, if that is not there, building the extension fails with a non helpful `This extension is not valid` error message. 
It's a small thing people constantly hit when building it for the first time. 
So it would be nice to just have an empty one here, that we can just use the clean checkout of this repo. 