### PR TITLE
Add Messages for Split Tunnel Message

### DIFF
--- a/en/messages.json
+++ b/en/messages.json
@@ -354,7 +354,7 @@
     "description": "Checkbox label on the settings page"
   },
   "messageSplitTunnelHeader": {
-    "message": "Re-enable Firefox protection",
+    "message": "Enable protection for Firefox",
     "description": "Header that is shown if the current Firefox is affected by Split-Tunneling"
   },
   "messageSplitTunnelBody": {

--- a/en/messages.json
+++ b/en/messages.json
@@ -352,5 +352,14 @@
   "telemetrySettingsCheckboxLabel": {
     "message": "This data helps us improve features and performance. It includes data about your device, hardware configuration, and how you use the Mozilla VPN extension.",
     "description": "Checkbox label on the settings page"
+  },
+  "messageSplitTunnelHeader": {
+    "message": "Re-enable Firefox protection",
+    "description": "Header that is shown if the current Firefox is affected by Split-Tunneling"
+  },
+  "messageSplitTunnelBody": {
+    "message": "Firefox is currently an “excluded app” in the Mozilla VPN application. To use this extension, open the application and go to Settings > Excluded Apps and remove Firefox.",
+    "description": "Helptext body that is shown if the current Firefox is affected by Split-Tunneling"
   }
+  
 }


### PR DESCRIPTION
This PR adds the Message Strings, whenever Firefox get's Split-Tunneled
![image](https://github.com/user-attachments/assets/bfea91b4-80a8-4600-9af2-1c392d2916c6)
