### PR TITLE
Change extension name for manifest.json only

### DIFF
--- a/en/messages.json
+++ b/en/messages.json
@@ -1,9 +1,8 @@
 {
-  "extensionName": {
-    "message": "Mozilla VPN Extension",
+  "extensionName2": {
+    "message": "Mozilla VPN Companion Extension",
     "description": "Name of the extension."
   },
-
   "extensionDescription": {
     "message": "Integrate VPN into Firefox: Exclude Tabs, set Site locations and more!",
     "description": "Description of the extension."


### PR DESCRIPTION
This PR changes the extension's name in the manifest to match the AMO store listing title. We do not currently intend to change the 'Mozilla VPN extension' verbiage elsewhere in the UI. 