### PR TITLE
FXVPN-441 Add Strings for 'subscription unavailable' screen

### DIFF
--- a/en/messages.json
+++ b/en/messages.json
@@ -366,7 +366,7 @@
     "description": "Helptext body that is shown if the current Firefox is affected by Split-Tunneling"
   },
   "headerSubscriptionNotAvailable": {
-    "message": "Mozilla VPN Subscriptions are not yet available in your country",
+    "message": "Mozilla VPN subscriptions are not yet available in your country",
     "description": "Header of an Error Screen, shown when the User is in a Country where Mozilla VPN is not offered."
   },
   "bodySubscriptionNotAvailable" :{

--- a/en/messages.json
+++ b/en/messages.json
@@ -364,6 +364,23 @@
   "messageSplitTunnelBody": {
     "message": "Firefox is currently an “excluded app” in the Mozilla VPN application. To use this extension, open the application and go to Settings > Excluded Apps and remove Firefox.",
     "description": "Helptext body that is shown if the current Firefox is affected by Split-Tunneling"
+  },
+  "headerSubscriptionNotAvailable": {
+    "message": "Mozilla VPN Subscriptions are not yet available in your country",
+    "description": "Header of an Error Screen, shown when the User is in a Country where Mozilla VPN is not offered."
+  },
+  "bodySubscriptionNotAvailable" :{
+    "message": "Mozilla VPN subscriptions are not available in your country yet, but you can join our waitlist to be notified when they launch. If you already have a subscription, please continue.",
+    "description" : "Body of an Error Screen, shown when the User is in a Country where Mozilla VPN is not offered."
+  },
+  "btnjoinWaitlist": {
+    "message": "Join the Waitlist",
+    "description" : "Button Text, shown when the User is in a Country where Mozilla VPN is not offered."
+  },
+  "btnContinue": {
+    "message": "Continue",
+    "description" : "Button Text, shown on an Error screen. Clicking it will continue the current flow."
   }
+
   
 }


### PR DESCRIPTION
Hellooo! I'm currently building a new message screen for users who are entering the VPN flow through the extension and are in a country that does not offer the vpn. So i'd like to add a few new strings. :) 

![image](https://github.com/user-attachments/assets/3b79dda2-f30b-4d36-9c9d-2b77a962d1e8)


PR: 
https://github.com/mozilla-extensions/mozilla-vpn-extension/pull/218