### PR TITLE
Add autostart settings strings

### DIFF
--- a/en/messages.json
+++ b/en/messages.json
@@ -383,7 +383,20 @@
   "btnContinue": {
     "message": "Continue",
     "description" : "Button Text, shown on an Error screen. Clicking it will continue the current flow."
+  },
+  "headlineAutoConnectOptions": {
+    "message": "Auto-connect options",
+    "description": "Headline for the Auto Connect options"
+  },
+  "labelDescribeAutoStartOnPBM":{
+    "message": "Always turn on VPN when using Private Browsing Mode"
+  },
+  "bodyAutoStartOnPBM": {
+    "message": " To turn this on, go to the add-ons menu, select “Mozilla VPN Extension”, and select “Allow” for “Run in Private Windows”.",
+    "description":"Body of the autostart option."
+  },
+  "labelDescribeAutoStart": {
+    "message": "Always turn on VPN when opening Firefox",
+    "description": "Description for the autostart checkbox"
   }
-
-  
 }

--- a/en/messages.json
+++ b/en/messages.json
@@ -392,7 +392,7 @@
     "message": "Always turn on VPN when using Private Browsing Mode"
   },
   "bodyAutoStartOnPBM": {
-    "message": " To turn this on, go to the add-ons menu, select “Mozilla VPN Extension”, and select “Allow” for “Run in Private Windows”.",
+    "message": "To turn this on, go to the add-ons menu, select “Mozilla VPN Extension”, and select “Allow” for “Run in Private Windows”.",
     "description":"Body of the autostart option."
   },
   "labelDescribeAutoStart": {


### PR DESCRIPTION
Hey! i'd like to add some strings related to "auto-start" feature coming to the vpn-extension :) 

![image](https://github.com/user-attachments/assets/ef2d7b34-7847-49c6-8a74-50ee889435bd)

See Also: 
https://github.com/mozilla-extensions/mozilla-vpn-extension/pull/239
https://github.com/mozilla-extensions/mozilla-vpn-extension/pull/241