### PR TITLE
remove unused strings

### DIFF
--- a/en/messages.json
+++ b/en/messages.json
@@ -304,17 +304,9 @@
     "message": "Learn what to do",
     "description": "Link in banner alert"
   },
-  "telemetry_toggle_text":{
-    "message": "Share technical and interaction data",
-    "description": "Label for the Telemetry Opt-In toggle"
-  },
   "privacy_notice_link_name": {
     "message": "Mozilla Subscription Services Privacy Notice",
     "description": "Used as text of the link in 'telemetry_screen_descr'"
-  },
-  "first-install-body": {
-    "message": "To help us improve features and performance and resolve issues quickly, you can choose to allow the Mozilla VPN extension to collect data. The data we collect will never be tied to you and we never collect data about the sites you visit. Data collection does not impact how the extension works.",
-    "description": "Body copy on the telemetry consent screen"
   },
   "privacyPolicyIntro": {
     "message": "Full details of the data we collect are available in our privacy policy.",
@@ -331,34 +323,6 @@
   "toContinueToTheExtension": {
     "message": "To continue to the extension, select the Mozilla VPN logo in the Firefox toolbar.",
     "description": "Blurb at the bottom of the telemetry consent screen"
-  },
-  "optionalDataCollection": {
-    "message": "Optional data collection",
-    "description": "Subtitle on the telemetry consent screen"
-  },
-  "telemetryListHeader": {
-    "message": "The optional data we collect includes:",
-    "description": "Headline for a list describing the type of data collected by the extension"
-  },
-  "technicalData": {
-    "message": "Technical data, such as browser version, extension version, and error details so we can track and fix errors efficiently.",
-    "description": "Description of technical data, found on telemetry consent screen."
-  },
-  "interactionData": {
-    "message": "Interaction data, such as the number of websites excluded from VPN protection, the number of websites with a location preference, and how often protection is turned on and off.",
-    "description": "Description of interaction data, found on the telemetry consent screen."
-  },
-  "telemetryOptOutInstructions": {
-    "message": "If you don’t want to allow the Mozilla VPN extension to collect data, uncheck the box. You can also change this setting anytime in the extension, under Settings.",
-    "description": "Opt out instructions on the telemetry consent screen"
-  },
-  "telemetryCheckboxLabel": {
-    "message": "Allow Mozilla to collect technical and interaction data",
-    "description": "Checkbox label"
-  },
-  "telemetrySettingsCheckboxLabel": {
-    "message": "This data helps us improve features and performance. It includes data about your device, hardware configuration, and how you use the Mozilla VPN extension.",
-    "description": "Checkbox label on the settings page"
   },
   "messageSplitTunnelHeader": {
     "message": "Enable protection for Firefox",


### PR DESCRIPTION
[This PR](https://github.com/mozilla-extensions/mozilla-vpn-extension/pull/269/changes) removed a bunch of strings. I cannot find other instances of these being used in the extension, so this PR removes them.